### PR TITLE
Fix error when plank schema key is missing

### DIFF
--- a/src/ThemeManager/DesktopTheme.py
+++ b/src/ThemeManager/DesktopTheme.py
@@ -92,9 +92,9 @@ class desktop_theme():
 		# Plank theme
 		if self.manager.plank_theme:
 			try:
-				os.system("gsettings set net.launchpad.plank.dock.settings:/net/launchpad/plank/docks/dock1/ theme %s" % nexttheme[9])
-			except CalledProcessError:
 				os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[9])
+			except subprocess.CalledProcessError:
+				os.system("gsettings set net.launchpad.plank.dock.settings:/net/launchpad/plank/docks/dock1/ theme %s" % nexttheme[9])
 			except:
 				module_logger.error("Either 'plank' is not installed or the plank theme %s is not present." % nexttheme[9])
 		
@@ -150,11 +150,13 @@ class desktop_theme():
 		# Plank theme
 		if self.manager.plank_theme:
 			try:
+				# backward compatibility for ubuntu <23.04
+				themes["Plank"] = self.run_command("gsettings get net.launchpad.plank.dock.settings theme")
+			except subprocess.CalledProcessError:
 				# For Ubuntu >=23.04
 				themes["Plank"] = self.run_command("gsettings get net.launchpad.plank.dock.settings:/net/launchpad/plank/docks/dock1/ theme")
 			except:
-				# backward compatibility for ubuntu <23.04
-				themes["Plank"] = self.run_command("gsettings get net.launchpad.plank.dock.settings theme")
+				module_logger.error("'plank' is not installed.")
 		
 		currenttheme["Themes"] = themes
 		


### PR DESCRIPTION
- Fix subprocess.CalledProcessError when theme key in plank's schema is missing or needs the schema path