### PR TITLE
Override dh_python to include python depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper-compat (= 13),
                meson,
                pybuild-plugin-pyproject,
                python3,
+               python3-docutils,
                python3-sphinx,
                python3-sphinx-argparse
 Standards-Version: 4.6.0

--- a/debian/requires.txt
+++ b/debian/requires.txt
@@ -1,0 +1,4 @@
+configobj
+PyGObject
+setproctitle
+tldextract

--- a/debian/rules
+++ b/debian/rules
@@ -27,3 +27,6 @@ override_dh_auto_build:
 override_dh_install:
 	dh_install -O--buildsystem=meson
 	install -D -m 0644 data/theme-manager-autostart.desktop.in debian/theme-manager/etc/xdg/autostart/theme-manager-autostart.desktop
+
+override_dh_python3:
+	dh_python3 -O--buildsystem=meson --requires debian/requires.txt


### PR DESCRIPTION
- Override dh_python3 to read python dependencies from file requires.txt
- Add docutils as build dependency